### PR TITLE
feat(1-4-observability): add opentelemetry

### DIFF
--- a/module7/project/README.md
+++ b/module7/project/README.md
@@ -138,9 +138,10 @@ uv run mypy src/
 **Completed Steps:**
 - ✅ Step 1.1: Project Initialization
 - ✅ Step 1.2: Configuration Management
+- ✅ Step 1.3: Basic Agent Setup with LangChain
 
 **Next Steps:**
-- ⏳ Step 1.3: Basic Agent Setup with LangChain
+
 - ⏳ Step 1.4: Observability (OpenTelemetry)
 - ⏳ Step 1.5: Conversation Persistence
 

--- a/module7/project/src/investigator_agent/observability/callbacks.py
+++ b/module7/project/src/investigator_agent/observability/callbacks.py
@@ -1,0 +1,97 @@
+"""LangChain callbacks for OpenTelemetry tracing.
+
+Implements :class:`TracingCallbackHandler` based on the Step 1.4 plan in
+PLAN_before.md.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from langchain.callbacks.base import BaseCallbackHandler
+from opentelemetry import trace
+
+
+class TracingCallbackHandler(BaseCallbackHandler):
+    """LangChain callback handler for OpenTelemetry tracing."""
+
+    def __init__(self, tracer: trace.Tracer) -> None:
+        self.tracer = tracer
+        self.spans: Dict[Any, Any] = {}
+
+    # LLM events ---------------------------------------------------------
+
+    def on_llm_start(self, serialized: dict[str, Any], prompts: List[str], **kwargs: Any) -> None:
+        """Start an LLM span when a model call begins."""
+
+        run_id = kwargs.get("run_id")
+        span = self.tracer.start_span("llm_call")
+        span.set_attribute("model", serialized.get("name", "unknown"))
+        span.set_attribute("prompts_count", len(prompts))
+        self.spans[run_id] = span
+
+    def on_llm_end(self, response: Any, **kwargs: Any) -> None:
+        """End the LLM span and record token usage if available."""
+
+        run_id = kwargs.get("run_id")
+        span = self.spans.get(run_id)
+        if not span:
+            return
+
+        # Extract token usage if provided by the backend
+        llm_output = getattr(response, "llm_output", None)
+        if isinstance(llm_output, dict):
+            token_usage = llm_output.get("token_usage", {})
+            span.set_attribute("input_tokens", token_usage.get("prompt_tokens", 0))
+            span.set_attribute("output_tokens", token_usage.get("completion_tokens", 0))
+            span.set_attribute("total_tokens", token_usage.get("total_tokens", 0))
+
+        span.end()
+        self.spans.pop(run_id, None)
+
+    def on_llm_error(self, error: Exception, **kwargs: Any) -> None:
+        """Record errors on the LLM span and end it."""
+
+        run_id = kwargs.get("run_id")
+        span = self.spans.get(run_id)
+        if not span:
+            return
+
+        span.set_attribute("error", str(error))
+        span.end()
+        self.spans.pop(run_id, None)
+
+    # Tool events --------------------------------------------------------
+
+    def on_tool_start(self, serialized: dict[str, Any], input_str: str, **kwargs: Any) -> None:
+        """Start a span for tool execution."""
+
+        run_id = kwargs.get("run_id")
+        span = self.tracer.start_span("tool_execution")
+        span.set_attribute("tool_name", serialized.get("name", "unknown"))
+        span.set_attribute("input", input_str[:500])
+        self.spans[run_id] = span
+
+    def on_tool_end(self, output: str, **kwargs: Any) -> None:
+        """End the tool span and record (truncated) output."""
+
+        run_id = kwargs.get("run_id")
+        span = self.spans.get(run_id)
+        if not span:
+            return
+
+        span.set_attribute("output", output[:500])
+        span.end()
+        self.spans.pop(run_id, None)
+
+    def on_tool_error(self, error: Exception, **kwargs: Any) -> None:
+        """Record errors on tool spans and end them."""
+
+        run_id = kwargs.get("run_id")
+        span = self.spans.get(run_id)
+        if not span:
+            return
+
+        span.set_attribute("error", str(error))
+        span.end()
+        self.spans.pop(run_id, None)

--- a/module7/project/src/investigator_agent/observability/tracer.py
+++ b/module7/project/src/investigator_agent/observability/tracer.py
@@ -1,0 +1,104 @@
+"""OpenTelemetry tracing setup for the Investigator Agent.
+
+Implements a simple file-based span exporter that writes JSON traces under
+``config.traces_dir``. This is the concrete implementation of the plan in
+PLAN_before.md Step 1.4.
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    SpanExportResult,
+    SpanExporter,
+)
+
+
+class FileSpanExporter(SpanExporter):
+    """Export spans to JSON files grouped by date.
+
+    The layout is:
+
+    ``traces_dir/YYYY-MM-DD/trace_HHMMSS.json``
+    """
+
+    def __init__(self, traces_dir: Path) -> None:
+        self.traces_dir = traces_dir
+        self.traces_dir.mkdir(parents=True, exist_ok=True)
+
+    def export(self, spans: Iterable["trace.Span"]) -> SpanExportResult:
+        """Export spans to a JSON file.
+
+        This implementation is intentionally simple and optimized for
+        debuggability rather than performance.
+        """
+
+        spans_list = list(spans)
+        if not spans_list:
+            return SpanExportResult.SUCCESS
+
+        try:
+            # Group by date
+            now = datetime.now()
+            date_str = now.strftime("%Y-%m-%d")
+            date_dir = self.traces_dir / date_str
+            date_dir.mkdir(exist_ok=True)
+
+            # File name based on time
+            timestamp = now.strftime("%H%M%S")
+            trace_file = date_dir / f"trace_{timestamp}.json"
+
+            # Convert spans to serializable dicts
+            trace_data = {
+                "timestamp": now.isoformat(),
+                "spans": [self._span_to_dict(span) for span in spans_list],
+            }
+
+            with trace_file.open("w", encoding="utf-8") as f:
+                json.dump(trace_data, f, indent=2)
+
+            return SpanExportResult.SUCCESS
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"Error exporting trace: {exc}")
+            return SpanExportResult.FAILURE
+
+    def _span_to_dict(self, span: Any) -> dict[str, Any]:
+        """Convert a span to a JSON-serializable dictionary."""
+
+        context = span.context
+        return {
+            "name": span.name,
+            "span_id": f"{context.span_id:016x}" if context else None,
+            "trace_id": f"{context.trace_id:032x}" if context else None,
+            "start_time": span.start_time,
+            "end_time": span.end_time,
+            "duration_ns": (span.end_time - span.start_time) if span.end_time else 0,
+            "attributes": dict(span.attributes) if getattr(span, "attributes", None) else {},
+            "status": str(span.status.status_code) if getattr(span, "status", None) else "UNSET",
+        }
+
+    def shutdown(self) -> None:  # pragma: no cover - no-op
+        """Shut down the exporter (no-op for file exporter)."""
+
+
+def setup_tracing(traces_dir: Path) -> trace.Tracer:
+    """Set up OpenTelemetry tracing with file-based exporter.
+
+    Returns the configured :class:`trace.Tracer` instance.
+    """
+
+    resource = Resource.create({"service.name": "investigator-agent"})
+
+    provider = TracerProvider(resource=resource)
+    exporter = FileSpanExporter(traces_dir)
+    processor = SimpleSpanProcessor(exporter)
+    provider.add_span_processor(processor)
+
+    trace.set_tracer_provider(provider)
+    return trace.get_tracer(__name__)

--- a/module7/project/tests/unit/test_observability.py
+++ b/module7/project/tests/unit/test_observability.py
@@ -1,0 +1,100 @@
+"""Tests for observability.tracer and observability.callbacks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from opentelemetry import trace
+
+from investigator_agent.observability.callbacks import TracingCallbackHandler
+from investigator_agent.observability.tracer import FileSpanExporter, setup_tracing
+
+
+def test_file_span_exporter_writes_trace_file(tmp_path: Path) -> None:
+    """FileSpanExporter should write a JSON file with spans."""
+
+    exporter = FileSpanExporter(tmp_path)
+
+    # Create a real tracer/span using OpenTelemetry SDK to ensure we have
+    # compatible objects. This is a minimal in-memory provider.
+    tracer_provider = trace.get_tracer_provider()
+    tracer = tracer_provider.get_tracer(__name__)
+    with tracer.start_as_current_span("test_span") as span:  # type: ignore[assignment]
+        spans = [span]
+
+    result = exporter.export(spans)
+    assert result.name == "SUCCESS"
+
+    # Verify a JSON trace file exists
+    date_dirs = list(tmp_path.iterdir())
+    assert date_dirs, "Expected date directory to be created"
+    trace_files = list(date_dirs[0].iterdir())
+    assert trace_files, "Expected at least one trace file"
+
+    with trace_files[0].open(encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert "spans" in data
+    assert isinstance(data["spans"], list)
+    assert data["spans"][0]["name"] == "test_span"
+
+
+def test_setup_tracing_returns_tracer(tmp_path: Path) -> None:
+    """setup_tracing should configure and return a tracer."""
+
+    tracer = setup_tracing(tmp_path)
+    assert isinstance(tracer, trace.Tracer)
+
+
+def test_tracing_callback_handler_llm_span_lifecycle() -> None:
+    """TracingCallbackHandler should create and finish LLM spans."""
+
+    tracer = MagicMock()
+    span = MagicMock()
+    tracer.start_span.return_value = span
+
+    handler = TracingCallbackHandler(tracer)
+    run_id = "run-123"
+
+    # Start
+    handler.on_llm_start({"name": "test-model"}, ["prompt"], run_id=run_id)
+    assert run_id in handler.spans
+
+    # End with token usage
+    response = SimpleNamespace(
+        llm_output={
+            "token_usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+        }
+    )
+    handler.on_llm_end(response, run_id=run_id)
+
+    # Span should be ended and removed
+    span.set_attribute.assert_any_call("input_tokens", 10)
+    span.set_attribute.assert_any_call("output_tokens", 5)
+    span.set_attribute.assert_any_call("total_tokens", 15)
+    span.end.assert_called_once()
+    assert run_id not in handler.spans
+
+
+def test_tracing_callback_handler_tool_span_lifecycle() -> None:
+    """TracingCallbackHandler should create and finish tool spans."""
+
+    tracer = MagicMock()
+    span = MagicMock()
+    tracer.start_span.return_value = span
+
+    handler = TracingCallbackHandler(tracer)
+    run_id = "tool-run-1"
+
+    handler.on_tool_start({"name": "my_tool"}, "input-data", run_id=run_id)
+    assert run_id in handler.spans
+
+    handler.on_tool_end("output-data", run_id=run_id)
+    span.set_attribute.assert_any_call("tool_name", "my_tool")
+    span.set_attribute.assert_any_call("input", "input-data")
+    span.set_attribute.assert_any_call("output", "output-data")
+    span.end.assert_called_once()
+    assert run_id not in handler.spans


### PR DESCRIPTION
## Summary
   Implements **Step 1.4: OpenTelemetry Observability with LangChain Callbacks**
   for the Investigator Agent.
   This PR adds a lightweight OpenTelemetry setup with a file-based span exporter
    and a LangChain callback handler. When tracing is enabled in `AgentConfig`,
   every LLM (and future tool) call is traced and written to human‑readable JSON
   files under `data/traces/`.
   ---
   ## Changes
   ### 1. Tracing setup and file exporter
   **File:** `src/investigator_agent/observability/tracer.py`
   - Added `FileSpanExporter(SpanExporter)`:
     - Writes spans to JSON files under:
       - `config.traces_dir / YYYY-MM-DD / trace_HHMMSS.json`
     - Structure per file:
       - Top-level metadata: `timestamp`
       - `spans`: list of span dicts containing:
         - `name`
         - `span_id`
         - `trace_id`
         - `start_time`
         - `end_time`
         - `duration_ns`
         - `attributes` (dict)
         - `status` (string)
   - Added `setup_tracing(traces_dir: Path) -> trace.Tracer`:
     - Creates `TracerProvider` with
   `Resource(service.name="investigator-agent")`.
     - Attaches `SimpleSpanProcessor(FileSpanExporter(traces_dir))`.
     - Registers provider globally via `trace.set_tracer_provider(...)`.
     - Returns a `Tracer` for use by the agent and callbacks.
   ### 2. LangChain tracing callbacks
   **File:** `src/investigator_agent/observability/callbacks.py`
   - Added `TracingCallbackHandler(BaseCallbackHandler)` to bridge LangChain
   events to OpenTelemetry:
     - Maintains an internal `self.spans` dict keyed by `run_id`.
     **LLM events:**
     - `on_llm_start(serialized, prompts, **kwargs)`:
       - Starts `"llm_call"` span.
       - Attributes:
         - `model` (from `serialized["name"]`, default `"unknown"`)
         - `prompts_count` (`len(prompts)`)
     - `on_llm_end(response, **kwargs)`:
       - Looks up span by `run_id`.
       - If `response.llm_output` has `token_usage`, records:
         - `input_tokens`
         - `output_tokens`
         - `total_tokens`
       - Ends span and removes it from `self.spans`.
     - `on_llm_error(error, **kwargs)`:
       - Records `error` attribute.
       - Ends span and removes it.
     **Tool events (future‑proofed for Phase 2 tools):**
     - `on_tool_start(serialized, input_str, **kwargs)`:
       - Starts `"tool_execution"` span.
       - Attributes:
         - `tool_name` (from `serialized["name"]`, default `"unknown"`)
         - `input` (truncated to 500 chars).
     - `on_tool_end(output, **kwargs)`:
       - Records `output` (truncated to 500 chars).
       - Ends span and removes it.
     - `on_tool_error(error, **kwargs)`:
       - Records `error` attribute.
       - Ends span and removes it.
   ### 3. Wiring observability into `InvestigatorAgent`
   **File:** `src/investigator_agent/agent.py`
   - New imports:
     - `TracingCallbackHandler` from `observability.callbacks`
     - `setup_tracing` from `observability.tracer`
   - In `__init__`, after initializing the LLM, memory, tools, and prompt:
     - Uses existing `AgentConfig.enable_tracing` and `AgentConfig.traces_dir`:
       - If `enable_tracing=True`:
         - Calls `self.tracer = setup_tracing(config.traces_dir)`.
         - Sets `self.callbacks = [TracingCallbackHandler(self.tracer)]`.
       - If `enable_tracing=False`:
         - Sets `self.tracer = None` and `self.callbacks = []`.
   - In `send_message`, passes callbacks to LangChain via `config`:
     config = {"callbacks": self.callbacks} if self.callbacks else None
     response = await self.llm.ainvoke(messages, config=config)
   - Behavior when tracing is disabled remains identical to Step 1.3.
   ---
   ## Testing
   From `module7/project`:
   uv run python -m pytest tests/unit -v
   Results:
   - **18 tests passed**, including:
     - Existing config tests (`test_config.py`)
     - Existing agent tests (`test_agent.py`)
     - New observability tests (`test_observability.py`)
   New tests added:
   **File:** `tests/unit/test_observability.py`
   - `test_file_span_exporter_writes_trace_file`
     - Verifies `FileSpanExporter.export`:
       - Produces a date directory under a temp traces dir.
       - Writes a JSON file containing a `spans` list.
       - Includes a span named `"test_span"`.
   - `test_setup_tracing_returns_tracer`
     - Ensures `setup_tracing(tmp_path)` returns a valid `trace.Tracer`.
   - `test_tracing_callback_handler_llm_span_lifecycle`
     - Uses `MagicMock` tracer/span:
       - `on_llm_start` registers span under `run_id`.
       - `on_llm_end` with token usage:
         - Records `input_tokens`, `output_tokens`, `total_tokens`.
         - Ends span and removes it from handler state.
   - `test_tracing_callback_handler_tool_span_lifecycle`
     - Verifies tool callbacks:
       - Records `tool_name`, `input`, and `output`.
       - Ends span and clears it from handler state.
   ---
   ## Manual verification (optional)
   With `GROQ_API_KEY` set and `enable_tracing=True` (default):
   1. From `module7/project`:
      uv run python cli.py
   2. Interact with the agent:
      - `You: Test observability`
      - `Agent: ...`
      - `You: exit`
   3. Inspect traces:
      ls data/traces
      ls data/traces/YYYY-MM-DD
      cat data/traces/YYYY-MM-DD/trace_*.json
   You should see at least one JSON file with LLM spans corresponding to your
   CLI interaction.